### PR TITLE
Fix some edge cases

### DIFF
--- a/server.go
+++ b/server.go
@@ -472,6 +472,9 @@ func (s *Server) handleSettings(ctx *connCtx, strm *Stream) error {
 	fr.SetType(FrameSettings)
 	fr.AddFlag(FlagAck)
 	err := ctx.writeFrame(fr)
+	if err == nil {
+		err = ctx.bw.Flush()
+	}
 
 	return err
 }

--- a/server.go
+++ b/server.go
@@ -365,10 +365,9 @@ func (s *Server) parseHeaders(ctx *connCtx, strm *Stream, isEnd bool) (err error
 	}
 
 	if err == nil {
-		if strm.ctx.Request.Header.IsGet() ||
-			strm.ctx.Request.Header.IsHead() {
+		if strm.hfr.EndStream() {
 			strm.istate = stateExecHandler
-		} else { // post, put or delete
+		} else {
 			strm.istate = stateAwaitData
 		}
 		strm.ctx.Request.SetRequestURIBytes(


### PR DESCRIPTION
This PR is related and closes this issue: https://github.com/dgrr/http2/issues/15

It fixes 2 edge cases:
1. Server hangs when client sends empty data payload within POST or PUT request. According to [the specs](https://httpwg.org/specs/rfc7540.html#n-examples) END_STREAM flag can be sent in headers if DATA will not follow.
2. Server make client hang waiting on setting acknowledgement when client sends setting frames during "handshake" phase