### PR TITLE
Fix "generic" specification

### DIFF
--- a/frameHeader.go
+++ b/frameHeader.go
@@ -177,6 +177,7 @@ func (frh *FrameHeader) readFrom(br *bufio.Reader, max uint32) (int64, error) {
 	// Parsing FrameHeader's Header field.
 	frh.parseValues(header)
 	if frh.kind > FrameContinuation {
+		br.Discard(frh.length)
 		return 0, ErrUnknowFrameType
 	}
 	frh.fr = AcquireFrame(frh.kind)

--- a/hpack.go
+++ b/hpack.go
@@ -395,25 +395,26 @@ func appendInt(dst []byte, bits uint8, index uint64) []byte {
 // https://tools.ietf.org/html/rfc7541#section-5.2
 func readString(dst, b []byte) ([]byte, []byte, error) {
 	var n uint64
-	var err error
 	if len(b) == 0 {
 		return b, dst, errors.New("no bytes left reading a string. Malformed data?")
 	}
 	mustDecode := b[0]&128 == 128 // huffman encoded
 	b, n = readInt(7, b)
 	if uint64(len(b)) < n {
-		err = fmt.Errorf("unexpected size: %d < %d", len(b), n)
+		return b, dst, UnexpectedSizeError
 	}
-	if err == nil {
-		if mustDecode {
-			dst = HuffmanDecode(dst, b[:n])
-		} else {
-			dst = append(dst, b[:n]...)
-		}
-		b = b[n:]
+
+	if mustDecode {
+		dst = HuffmanDecode(dst, b[:n])
+	} else {
+		dst = append(dst, b[:n]...)
 	}
-	return b, dst, err
+	b = b[n:]
+
+	return b, dst, nil
 }
+
+var UnexpectedSizeError  = errors.New("unexpected size")
 
 // appendString writes bytes slice to dst and returns it.
 // https://tools.ietf.org/html/rfc7541#section-5.2

--- a/server.go
+++ b/server.go
@@ -98,6 +98,10 @@ func (s *Server) ServeConn(c net.Conn) error {
 	for err == nil {
 		fr, err = ReadFrameFrom(sc.br)
 		if err != nil {
+			if errors.Is(err, ErrUnknowFrameType) {
+				err = nil
+				continue
+			}
 			break
 		}
 

--- a/server.go
+++ b/server.go
@@ -154,6 +154,7 @@ func (s *Server) ServeConn(c net.Conn) error {
 
 func (sc *serverConn) handlePing(ping *Ping) {
 	fr := AcquireFrameHeader()
+	ping.SetAck(true)
 	fr.SetBody(ping)
 
 	sc.writer <- fr

--- a/stream.go
+++ b/stream.go
@@ -41,6 +41,7 @@ type Stream struct {
 	state     StreamState
 	ctx       *fasthttp.RequestCtx
 	startedAt time.Time
+	previousHeaderBytes []byte
 }
 
 var streamPool = sync.Pool{


### PR DESCRIPTION
This PR fixes the [h2spec](https://github.com/summerwind/h2spec) "generic" part.

```
44 tests, 44 passed, 0 skipped, 0 failed
 ```

## details
 - Fix ping frame that needs an ack ping frame in response.
 - Fix ignoring unkown frame.
 - Fix partial header body with end of the body in a continuation frame.

For the partial header handling, this is a implementation proposal, things can be done differently, happy to talk about it.
