### PR TITLE
Handling section4 of http2 spec

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -97,5 +97,5 @@ var (
 	ErrMissingBytes = NewError(
 		ProtocolError, "missing payload bytes. Need more")
 	ErrPayloadExceeds = NewError(
-		ProtocolError, "FrameHeader payload exceeds the negotiated maximum size")
+		FrameSizeError, "FrameHeader payload exceeds the negotiated maximum size")
 )

--- a/errors.go
+++ b/errors.go
@@ -42,6 +42,7 @@ func (e ErrorCode) Error() string {
 // Error defines the HTTP/2 errors, composed by the code and debug data.
 type Error struct {
 	code  ErrorCode
+	frameType FrameType
 	debug string
 }
 
@@ -65,6 +66,15 @@ func NewError(e ErrorCode, debug string) Error {
 	return Error{
 		code:  e,
 		debug: debug,
+		frameType: FrameResetStream,
+	}
+}
+
+func NewGoAwayError(e ErrorCode, debug string) Error {
+	return Error{
+		code:  e,
+		debug: debug,
+		frameType: FrameGoAway,
 	}
 }
 
@@ -98,4 +108,6 @@ var (
 		ProtocolError, "missing payload bytes. Need more")
 	ErrPayloadExceeds = NewError(
 		FrameSizeError, "FrameHeader payload exceeds the negotiated maximum size")
+	ErrCompression = NewGoAwayError(
+		CompressionError, "Compression error")
 )

--- a/goaway.go
+++ b/goaway.go
@@ -85,7 +85,7 @@ func (ga *GoAway) Deserialize(fr *FrameHeader) (err error) {
 	if len(fr.payload) < 8 { // 8 is the min number of bytes
 		err = ErrMissingBytes
 	} else {
-		ga.code = ErrorCode(http2utils.BytesToUint32(fr.payload))
+		ga.stream = http2utils.BytesToUint32(fr.payload)
 		ga.code = ErrorCode(http2utils.BytesToUint32(fr.payload[4:]))
 		// TODO: what?
 

--- a/server.go
+++ b/server.go
@@ -96,7 +96,7 @@ func (s *Server) ServeConn(c net.Conn) error {
 	c.SetReadDeadline(time.Time{})
 
 	for err == nil {
-		fr, err = ReadFrameFrom(sc.br)
+		fr, err = ReadFrameFromWithSize(sc.br, sc.clientS.frameSize)
 		if err != nil {
 			if errors.Is(err, ErrUnknowFrameType) {
 				err = nil

--- a/server.go
+++ b/server.go
@@ -208,17 +208,19 @@ func (sc *serverConn) handleStreams() {
 			}
 
 			handleState(fr, strm)
+			if fr.Type() == FrameHeaders && fr.Flags().Has(FlagEndHeaders) {
+				currentStrm = 0
+			}
 
 			if strm.State() < StreamStateHalfClosed && sc.readTimeout > 0 {
 				if time.Since(strm.startedAt) > sc.readTimeout {
-					sc.writeGoAway(strm.ID(), StreamCancelled, "")
+					sc.writeGoAway(strm.ID(), StreamCancelled, "timeout")
 					strm.SetState(StreamStateClosed)
 				}
 			}
 
 			switch strm.State() {
 			case StreamStateHalfClosed:
-				currentStrm = 0
 				sc.handleEndRequest(strm)
 				fallthrough
 			case StreamStateClosed:

--- a/settings.go
+++ b/settings.go
@@ -9,7 +9,7 @@ const (
 	defaultHeaderTableSize   uint32 = 4096
 	defaultConcurrentStreams uint32 = 100
 	defaultWindowSize        uint32 = 1048896
-	defaultDataFrameSize     uint32 = 1048896
+	defaultDataFrameSize     uint32 = 1<<14
 	defaultMaxHeaderListSize uint32 = 1048896
 
 	windowSize   = 1<<31 - 1

--- a/settings.go
+++ b/settings.go
@@ -8,7 +8,7 @@ const (
 	// default Settings parameters
 	defaultHeaderTableSize   uint32 = 4096
 	defaultConcurrentStreams uint32 = 100
-	defaultWindowSize        uint32 = 1048896
+	defaultWindowSize        uint32 = 1<<16-1
 	defaultDataFrameSize     uint32 = 1<<14
 	defaultMaxHeaderListSize uint32 = 1048896
 


### PR DESCRIPTION
This PR handles the section 4 of the http2 spec

```
❯ ~/h2spec -t -k -p 8443  http2/4
Hypertext Transfer Protocol Version 2 (HTTP/2)
  4. HTTP Frames
    4.1. Frame Format
      ✔ 1: Sends a frame with unknown type
      ✔ 2: Sends a frame with undefined flag
      ✔ 3: Sends a frame with reserved field bit

    4.2. Frame Size
      ✔ 1: Sends a DATA frame with 2^14 octets in length
      ✔ 2: Sends a large size DATA frame that exceeds the SETTINGS_MAX_FRAME_SIZE
      ✔ 3: Sends a large size HEADERS frame that exceeds the SETTINGS_MAX_FRAME_SIZE

    4.3. Header Compression and Decompression
      ✔ 1: Sends invalid header block fragment
      ✔ 2: Sends a PRIORITY frame while sending the header blocks
      ✔ 3: Sends a HEADERS frame to another stream while sending the header blocks

Finished in 0.0538 seconds
9 tests, 9 passed, 0 skipped, 0 failed
```

## details
 - Fix MAX_FRAME_SIZE
   - Handle error when frame exceed
   - Change the default size to respect spec
 - Fix COMPRESSION
   - COMPRESSION_ERROR is a GoAway
   - Change error system to handle GoAway error
   - Remove the stream on the GoAway frame header because, "the GOAWAY frame applies to the connection, not a specific stream."
 - Fix wrong frame ( wrong type or wrong stream ) while receiving HEADERS