### PR TITLE
Fix creation of streams with RST_FRAME.

### DIFF
--- a/server.go
+++ b/server.go
@@ -190,6 +190,10 @@ func (sc *serverConn) handleStreams() {
 					continue
 				}
 
+				if fr.Type() == FrameResetStream {
+					continue
+				}
+
 				strm = NewStream(fr.Stream(), sc.clientStreamWindow)
 				strms[fr.Stream()] = strm
 


### PR DESCRIPTION
This PR fixes a performance issue + timeouts.

After the end of the stream (remove from the stream map) sometimes some RST_STREAM can happen and  then recreate streams.
As RST_STREAM should never happen first on a stream, ignoring those frame for the creation fixes the problem.


Before:
```
❯ hey -c 100 -z 30s -h2 -t 5 https://127.0.0.1:8443

Summary:
  Total:	30.3452 secs
  Slowest:	0.0182 secs
  Fastest:	0.0001 secs
  Average:	0.0026 secs
  Requests/sec:	430.7106
  
  Total data:	124700 bytes
  Size/request:	10 bytes

Response time histogram:
  0.000 [1]	|
  0.002 [2595]	|■■■■■■■■■■■■
  0.004 [8440]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.006 [1212]	|■■■■■■
  0.007 [153]	|■
  0.009 [25]	|
  0.011 [11]	|
  0.013 [8]	|
  0.015 [12]	|
  0.016 [8]	|
  0.018 [5]	|


Latency distribution:
  10% in 0.0013 secs
  25% in 0.0020 secs
  50% in 0.0026 secs
  75% in 0.0031 secs
  90% in 0.0038 secs
  95% in 0.0044 secs
  99% in 0.0063 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0001 secs, 0.0182 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0043 secs
  resp wait:	0.0008 secs, 0.0000 secs, 0.0041 secs
  resp read:	0.0002 secs, 0.0000 secs, 0.0041 secs

Status code distribution:
  [200]	12470 responses

Error distribution:
  [87]	Get "https://127.0.0.1:8443": context deadline exceeded
  [513]	Get "https://127.0.0.1:8443": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

After
```
❯ hey -c 100 -z 30s -h2 -t 5 https://127.0.0.1:8443

Summary:
  Total:	30.0029 secs
  Slowest:	0.0283 secs
  Fastest:	0.0000 secs
  Average:	0.0030 secs
  Requests/sec:	40354.8588
  
  Total data:	12107620 bytes
  Size/request:	12 bytes

Response time histogram:
  0.000 [1]	|
  0.003 [676267]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.006 [321576]	|■■■■■■■■■■■■■■■■■■■
  0.009 [2023]	|
  0.011 [34]	|
  0.014 [17]	|
  0.017 [23]	|
  0.020 [24]	|
  0.023 [15]	|
  0.025 [5]	|
  0.028 [15]	|


Latency distribution:
  10% in 0.0012 secs
  25% in 0.0020 secs
  50% in 0.0025 secs
  75% in 0.0030 secs
  90% in 0.0035 secs
  95% in 0.0039 secs
  99% in 0.0048 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0000 secs, 0.0283 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0051 secs
  resp wait:	0.0009 secs, 0.0000 secs, 0.0139 secs
  resp read:	0.0002 secs, 0.0000 secs, 0.0067 secs

Status code distribution:
  [200]	1000000 responses
```