### PR TITLE
client add proxy support

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -42,6 +42,7 @@ func ConfigureClient(c *fasthttp.HostClient, opts ClientOpts) error {
 		Addr:         c.Addr,
 		TLSConfig:    c.TLSConfig,
 		PingInterval: opts.PingInterval,
+		NetDial:      c.Dial,
 	}
 
 	cl := createClient(d, opts)


### PR DESCRIPTION
code from fasthttp client example

`
import (
	"github.com/valyala/fasthttp/fasthttpproxy"
)

// ...
		hostWithPort := "example.com:80"

		client := &fasthttp.HostClient{
			Addr:                hostWithPort,
		}

		if proxyUrl != "" {
			if "http" == proxyUrl[:4] {
				client.Dial = fasthttpproxy.FasthttpHTTPDialer(proxyUrl)
			} else {
				client.Dial = fasthttpproxy.FasthttpSocksDialer(proxyUrl)
			}
		}

		e = http2.ConfigureClient(client, http2.ClientOpts{})
		if e != nil {
			return
		}
`