### PR TITLE
Fix response writer goroutine leaks and channel block

### DIFF
--- a/frameHeader.go
+++ b/frameHeader.go
@@ -216,7 +216,7 @@ func (f *FrameHeader) readFrom(br *bufio.Reader) (int64, error) {
 	return rn, f.fr.Deserialize(f)
 }
 
-// WriteTo writes frame to the Writer.
+// WriteTo writes frame to the writer.
 //
 // This function returns FrameHeader bytes written and/or error.
 func (f *FrameHeader) WriteTo(w *bufio.Writer) (wb int64, err error) {

--- a/hpack.go
+++ b/hpack.go
@@ -326,7 +326,7 @@ loop:
 			bytePool.Put(dst)
 		}
 
-	// Dynamic Table Size Update
+	// Dynamic Table size Update
 	// Changes the size of the dynamic table.
 	// https://tools.ietf.org/html/rfc7541#section-6.3
 	case c&32 == 32: // 001- ----


### PR DESCRIPTION
If the client closes the connection directly without catching the error, the writer's channel will block and the goroutine will leak.