### PR TITLE
Fix response writer goroutine leaks and channel block

### DIFF
--- a/server.go
+++ b/server.go
@@ -621,7 +621,7 @@ func (s *streamWrite) ReadFrom(r io.Reader) (num int64, err error) {
 			return num, err
 		}
 		num += int64(n)
-		if err != nil || (s.size >= 0 && num >= s.size) {
+		if s.size >= 0 && num >= s.size {
 			break
 		}
 	}


### PR DESCRIPTION
If the client closes the connection directly without catching the error, the writer's channel will block and the goroutine will leak.