### PR TITLE
:zap:perf(hpack): Refactor tableSize to uint32 to improving perfromance

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -247,7 +247,7 @@ func (c *Conn) Handshake() error {
 
 			c.serverStreamWindow += int32(c.serverS.MaxWindowSize())
 			if st.HeaderTableSize() <= defaultHeaderTableSize {
-				c.enc.SetMaxTableSize(int(st.HeaderTableSize()))
+				c.enc.SetMaxTableSize(st.HeaderTableSize())
 			}
 
 			// reply back
@@ -643,7 +643,7 @@ func (c *Conn) handleSettings(st *Settings) {
 	st.CopyTo(&c.serverS)
 
 	c.serverStreamWindow += int32(c.serverS.MaxWindowSize())
-	c.enc.SetMaxTableSize(int(st.HeaderTableSize()))
+	c.enc.SetMaxTableSize(st.HeaderTableSize())
 
 	// reply back
 	fr := AcquireFrameHeader()

--- a/headerField.go
+++ b/headerField.go
@@ -57,8 +57,8 @@ func (hf *HeaderField) AppendBytes(dst []byte) []byte {
 // Size returns the header field size as RFC specifies.
 //
 // https://tools.ietf.org/html/rfc7541#section-4.1
-func (hf *HeaderField) Size() int {
-	return len(hf.key) + len(hf.value) + 32
+func (hf *HeaderField) Size() uint32 {
+	return uint32(len(hf.key) + len(hf.value) + 32)
 }
 
 // CopyTo copies the HeaderField to `other`.

--- a/hpack.go
+++ b/hpack.go
@@ -34,7 +34,7 @@ type HPACK struct {
 	// dynamic_length - (input_index - 62) - 1
 	dynamic []*HeaderField
 
-	maxTableSize int
+	maxTableSize uint32
 }
 
 func headerFieldsToString(hfs []*HeaderField, indexOffset int) string {
@@ -50,7 +50,7 @@ func headerFieldsToString(hfs []*HeaderField, indexOffset int) string {
 var hpackPool = sync.Pool{
 	New: func() interface{} {
 		return &HPACK{
-			maxTableSize: int(defaultHeaderTableSize),
+			maxTableSize: uint32(defaultHeaderTableSize),
 			dynamic:      make([]*HeaderField, 0, 16),
 		}
 	},
@@ -81,19 +81,19 @@ func (hp *HPACK) releaseDynamic() {
 // Reset deletes and releases all dynamic header fields.
 func (hp *HPACK) Reset() {
 	hp.releaseDynamic()
-	hp.maxTableSize = int(defaultHeaderTableSize)
+	hp.maxTableSize = uint32(defaultHeaderTableSize)
 	hp.DisableCompression = false
 }
 
 // SetMaxTableSize sets the maximum dynamic table size.
-func (hp *HPACK) SetMaxTableSize(size int) {
+func (hp *HPACK) SetMaxTableSize(size uint32) {
 	hp.maxTableSize = size
 }
 
 // DynamicSize returns the size of the dynamic table.
 //
 // https://tools.ietf.org/html/rfc7541#section-4.1
-func (hp *HPACK) DynamicSize() (n int) {
+func (hp *HPACK) DynamicSize() (n uint32) {
 	for _, hf := range hp.dynamic {
 		n += hf.Size()
 	}
@@ -331,7 +331,7 @@ loop:
 	// https://tools.ietf.org/html/rfc7541#section-6.3
 	case c&32 == 32: // 001- ----
 		b, n = readInt(5, b)
-		hp.maxTableSize = int(n)
+		hp.maxTableSize = uint32(n)
 		hp.shrink()
 		goto loop
 	}


### PR DESCRIPTION
The size of table must to be unsigned number, use uint32 instead of int will be better.